### PR TITLE
step 6: dockerfile for jupyternotebook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM jupyter/r-notebook:x86_64-ubuntu-22.04
+
+RUN Rscript -e "install.packages('remotes', repos='https://cloud.r-project.org')"
+
+RUN Rscript -e "remotes::install_version('reticulate', version='1.25.0', repos='https://cloud.r-project.org')"
+RUN Rscript -e "remotes::install_version('ROSE', version='0.0-4', repos='https://cloud.r-project.org')"
+RUN Rscript -e "remotes::install_version('patchwork', version='1.3.0', repos='https://cloud.r-project.org')"
+
+RUN Rscript -e "reticulate::py_install('pandas', method = 'conda')"
+RUN Rscript -e "reticulate::py_install('ucimlrepo', method = 'conda')"


### PR DESCRIPTION
dockerfile for creating the docker that works with jupyternotebook.
The docker is build under: kayleeli/dsci310_g6_milestone1

docker-compose will be created later