### PR TITLE
created docker-compose.yml for jupyternotebook

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  report-env:
+    image: kayleeli/dsci310_g6_milestone1
+    ports:
+      - "10000:8888"
+    volumes:
+      - ./reports:/home/jovyan/work/reports
+      - ./data:/home/jovyan/work/data
+      - ./src:/home/jovyan/work/src
+    command: start-notebook.sh --NotebookApp.token=''


### PR DESCRIPTION
The Docker Compose file for launching Jupyter Notebook has been completed.

To run it, navigate to the dsci-310-group-06 folder and execute:

```
docker-compose up
```

To stop and remove the container, run:

```
docker-compose rm
```

Please check that this is run-able on both mac + window. 



I've confirmed this works on window.
