### PR TITLE
update roc_plot.R to resolve interactive issue.

### DIFF
--- a/R/roc_plot.R
+++ b/R/roc_plot.R
@@ -45,6 +45,9 @@ roc_plot <- function(model_outputs, true_class, predicted_probs, roc_auc_value, 
     stop("Error: Output file path cannot be empty.")
   }
   
+  # solve interactive issue
+  if(!interactive()) pdf(NULL)
+  
   # Create the ROC plot
   roc_curve_data <- yardstick::roc_curve(
     model_outputs, 


### PR DESCRIPTION
Realized that the `Rplots.pdf` file is created when R opens a default graphical device (like `pdf()`) without a file name. 

To prevent this, added `if(!interactive()) pdf(NULL)`.