### PR TITLE
Update testthat with test_dir

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -6,7 +6,10 @@
 # * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
 # * https://testthat.r-lib.org/articles/special-files.html
 
-library(testthat)
-library(dsci-310-group-06)
+# Notes:
+# library() + test_check() is package-specific. Milestone 3 hasn't made the function a package yet, so using source() + test_dir() instead.
 
-test_check("dsci-310-group-06")
+library(testthat)
+testthat::test_dir("work/tests/testthat/")  
+  
+


### PR DESCRIPTION
default testthat create testthat.R that uses library() and test_check().

We haven't got the stage for making packages in milestone3.  Change to test_dir instead.